### PR TITLE
feat(react-display-name): disable rule

### DIFF
--- a/eslint-config-landr/package.json
+++ b/eslint-config-landr/package.json
@@ -1,7 +1,7 @@
 {
     "name": "eslint-config-landr",
     "description": "LANDR's shareable ESLint config",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "main": "index.js",
     "license": "MIT",
     "author": "Robert Cooper <rcooper@landr.com>",

--- a/eslint-config-landr/react.js
+++ b/eslint-config-landr/react.js
@@ -9,6 +9,7 @@ module.exports = {
     },
     rules: {
         'react/prop-types': 0,
+        'react/display-name': 0,
         'react/self-closing-comp': [
             'error',
             {


### PR DESCRIPTION
## Description
Pr will disable react/display-name rule.
It prohibits defining inline components with arrow functions and requires definition with named function instead.
Example from here (https://github.com/yannickcr/eslint-plugin-react/issues/597):
```
//warn
const wrapWithToastProvider = Comp => props => (
	<ToastProvider>
		<Comp {...props} />
	</ToastProvider>
);
// no warn
function wrapWithToastProvider(Comp) {
  return function WrappedWithToast(props) {
    return (
		<ToastProvider>
			<Comp {...props} />
		</ToastProvider>
    );
  };
}
```

## Checklist

- [x] Updated the version number in the `package.json`
- [x] Test any new configuration on a repo using [`npm link`](https://docs.npmjs.com/cli/link)
