### PR TITLE
Fix: fix peer dependencies and use prettier 2.X

### DIFF
--- a/eslint-config-landr/package.json
+++ b/eslint-config-landr/package.json
@@ -26,7 +26,7 @@
         "eslint-config-prettier": "^4.1.0",
         "eslint-plugin-import": "^2.17.2",
         "eslint-plugin-prettier": "^3.0.1",
-        "prettier": "^1.16.4",
+        "prettier": "^1.19",
         "typescript": "^3.3.3333"
     },
     "engines": {

--- a/eslint-config-landr/package.json
+++ b/eslint-config-landr/package.json
@@ -1,7 +1,7 @@
 {
     "name": "eslint-config-landr",
     "description": "LANDR's shareable ESLint config",
-    "version": "0.2.3",
+    "version": "0.3.0",
     "main": "index.js",
     "license": "MIT",
     "author": "Robert Cooper <rcooper@landr.com>",
@@ -23,10 +23,10 @@
         "@typescript-eslint/parser": "^1.4.2",
         "eslint-plugin-react-hooks": "^4.0.8",
         "eslint": "5.x || 6.x",
-        "eslint-config-prettier": "^4.1.0",
-        "eslint-plugin-import": "^2.17.2",
-        "eslint-plugin-prettier": "^3.0.1",
-        "prettier": "^1.19",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-prettier": "^3.1.0",
+        "prettier": "^2.x",
         "typescript": "^3.3.3333"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
         "@typescript-eslint/eslint-plugin": "^2.20.0",
         "@typescript-eslint/parser": "^2.20.0",
         "eslint": "^6.8.0",
-        "eslint-config-landr": "^0.1.0",
+        "eslint-config-landr": "^0.2.3",
         "eslint-config-prettier": "^6.10.0",
         "eslint-plugin-prettier": "^3.1.2",
-        "prettier": "^1.19.1",
-        "prettier-config-landr": "^0.0.6",
+        "prettier": "^2.1.2",
+        "prettier-config-landr": "^0.0.7",
         "typescript": "^3.7.5"
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
         "@typescript-eslint/eslint-plugin": "^2.20.0",
         "@typescript-eslint/parser": "^2.20.0",
         "eslint": "^6.8.0",
-        "eslint-config-landr": "^0.2.3",
+        "eslint-config-landr": "^0.3.0",
         "eslint-config-prettier": "^6.10.0",
         "eslint-plugin-prettier": "^3.1.2",
         "prettier": "^2.1.2",
-        "prettier-config-landr": "^0.0.7",
+        "prettier-config-landr": "^0.1.0",
         "typescript": "^3.7.5"
     }
 }

--- a/prettier-config-landr/package.json
+++ b/prettier-config-landr/package.json
@@ -12,9 +12,9 @@
         "prettier"
     ],
     "devDependencies": {
-        "prettier": "^1.19.1"
+        "prettier": "^2.1.2"
     },
     "peerDependencies": {
-        "prettier": "^1.16.x"
+        "prettier": "^1.19"
     }
 }

--- a/prettier-config-landr/package.json
+++ b/prettier-config-landr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prettier-config-landr",
-    "version": "0.0.7",
+    "version": "0.1.0",
     "description": "LANDR's shareable Prettier config",
     "main": "index.js",
     "repository": "https://github.com/Mixgenius/linting-and-formatting/tree/master/prettier-config-landr",
@@ -15,6 +15,6 @@
         "prettier": "^2.1.2"
     },
     "peerDependencies": {
-        "prettier": "^1.19"
+        "prettier": "^2.x"
     }
 }


### PR DESCRIPTION
## Description
Bump dependencies to fix Peer dependencies issues in other repos.

We are now using Prettier 2.x 

## Checklist

- [x] Updated the version number in the `package.json`
- [x] Test any new configuration on a repo using [`npm link`](https://docs.npmjs.com/cli/link)

https://mixgenius.atlassian.net/browse/CHFE-578