### PR TITLE
fix: remove jira from opensource repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "devDependencies": {
         "@auto-it/all-contributors": "^9.58.0",
         "@auto-it/conventional-commits": "^9.58.0",
-        "@auto-it/jira": "^9.58.0",
         "@typescript-eslint/eslint-plugin": "^2.20.0",
         "@typescript-eslint/parser": "^2.20.0",
         "auto": "^9.58.0",
@@ -38,7 +37,6 @@
                 }
             ],
             "conventional-commits",
-            "jira",
             "released"
         ]
     }


### PR DESCRIPTION
## Description
Remove jira from opensource repo


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-config-landr@0.4.1-canary.58.a5469cc.0
  npm install prettier-config-landr@0.1.2-canary.58.a5469cc.0
  npm install stylelint-config-landr@0.0.7-canary.58.a5469cc.0
  # or 
  yarn add eslint-config-landr@0.4.1-canary.58.a5469cc.0
  yarn add prettier-config-landr@0.1.2-canary.58.a5469cc.0
  yarn add stylelint-config-landr@0.0.7-canary.58.a5469cc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
