### PR TITLE
feat: disable no use before define

### DIFF
--- a/packages/eslint-config-landr/index.js
+++ b/packages/eslint-config-landr/index.js
@@ -100,7 +100,6 @@ module.exports = {
                 '@typescript-eslint/class-name-casing': 'error',
                 '@typescript-eslint/no-inferrable-types': 'error',
                 '@typescript-eslint/type-annotation-spacing': 'error',
-                '@typescript-eslint/no-use-before-define': 'error',
                 // you must disable the base rule no-unused-vars as it can report incorrect errors
                 "no-unused-vars": "off",
                 '@typescript-eslint/no-unused-vars': [

--- a/packages/eslint-config-landr/index.js
+++ b/packages/eslint-config-landr/index.js
@@ -100,6 +100,8 @@ module.exports = {
                 '@typescript-eslint/class-name-casing': 'error',
                 '@typescript-eslint/no-inferrable-types': 'error',
                 '@typescript-eslint/type-annotation-spacing': 'error',
+                "no-use-before-define": "off",
+                "@typescript-eslint/no-use-before-define": "off",
                 // you must disable the base rule no-unused-vars as it can report incorrect errors
                 "no-unused-vars": "off",
                 '@typescript-eslint/no-unused-vars': [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2888,6 +2888,13 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+eslint-config-landr@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-landr/-/eslint-config-landr-0.4.1.tgz#dccdda4d80486d73833d6c4bff145c5fa31d3241"
+  integrity sha512-kd5RVwGqA36o7Yg+CfPzEMbxGLWUhNVETx5HLdbexapT1A9NdW6MkBWOZWmM1S2cS1pmcWSkJVuFIVK5oYwOVA==
+  optionalDependencies:
+    eslint-plugin-react "^7.18.3"
+
 eslint-config-prettier@^6.10.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.13.0.tgz#207d88796b5624e5bb815bbbdfc5891ceb9ebffa"
@@ -2952,6 +2959,23 @@ eslint-plugin-react@^7.18.3:
     object.values "^1.1.1"
     prop-types "^15.7.2"
     resolve "^1.17.0"
+    string.prototype.matchall "^4.0.2"
+
+eslint-plugin-react@^7.21.5:
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz#50b21a412b9574bfe05b21db176e8b7b3b15bff3"
+  integrity sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==
+  dependencies:
+    array-includes "^3.1.1"
+    array.prototype.flatmap "^1.2.3"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.4.1 || ^3.0.0"
+    object.entries "^1.1.2"
+    object.fromentries "^2.0.2"
+    object.values "^1.1.1"
+    prop-types "^15.7.2"
+    resolve "^1.18.1"
     string.prototype.matchall "^4.0.2"
 
 eslint-scope@^5.0.0:
@@ -4138,6 +4162,13 @@ is-ci@^2.0.0:
   integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
   dependencies:
     ci-info "^2.0.0"
+
+is-core-module@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
+  integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+  dependencies:
+    has "^1.0.3"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -5929,6 +5960,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier-config-landr@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/prettier-config-landr/-/prettier-config-landr-0.1.2.tgz#f3416776d80f23c96ea9c8ae01291874a8dc88bc"
+  integrity sha512-6C/1XO8qh3zf271MTyB4CR5qi9aU01Q4obQK1nlaXOL4xvke6hv7pH3Yerw+t4ipSIWKHYqqBCgOAOO6H5Dk6w==
+
 prettier-linter-helpers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
@@ -6422,6 +6458,14 @@ resolve@^1.10.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.18.1:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
+  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  dependencies:
+    is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
 restore-cursor@^2.0.0:


### PR DESCRIPTION
## Description

There’s a rule in our eslint config called no-use-before-define which forces us to declare functions before executing them.
In JavaScript, functions are hoisted by the interpreter automatically before being executed and that’s always been the case.

That means that something like this is super legit

```tsx
toto()
function toto(){
  console.log("hi")
}
```

This is the same kind of behaviours you can expect when calling methods in classes.
Declarations are interpreted first, initializations after.

But our rule stops us from using this language feature and often gets in the way when splitting complex functions into smaller functions by complaining about a useless ordering issue.

I feel it also obfuscates files because the file thing you see in a file are sub functions used by the main export because they need to be declared first, just because of the eslint rule

But there’s a bright side to all of this: this rule can be disabled!

And even when disabled, Typescript still warns us for using variables before.

No technically there is no risks or unwanted side effects of disabling this.

```tsx
console.log(toto); // Block-scoped variable 'toto' used before its declaration (TypeScript)
const toto = 3;
```

The rule exists because, according to ESLint, `This can be confusing and some believe it is best to always declare variables and functions before using them`.

But then, MDN says `One of the advantages of JavaScript putting function declarations into memory before it executes any code segment is that it allows you to use a function before you declare it in your code`

I feel like we should all understand how hoisting works so that we can use this tool when we feel it can be useful.

## Checklist

- [x] Test any new configuration on a repo using [`npm link`](https://docs.npmjs.com/cli/link)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-config-landr@0.5.1-canary.69.6c3390b.0
  npm install prettier-config-landr@0.2.1-canary.69.6c3390b.0
  npm install stylelint-config-landr@0.1.1-canary.69.6c3390b.0
  # or 
  yarn add eslint-config-landr@0.5.1-canary.69.6c3390b.0
  yarn add prettier-config-landr@0.2.1-canary.69.6c3390b.0
  yarn add stylelint-config-landr@0.1.1-canary.69.6c3390b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
