### PR TITLE
fix: udpate peer dependencies

### DIFF
--- a/packages/eslint-config-landr/package.json
+++ b/packages/eslint-config-landr/package.json
@@ -19,15 +19,15 @@
         "url": "https://github.com/Mixgenius/linting-and-formatting/tree/master/eslint-config-landr"
     },
     "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^4.9.0",
-        "@typescript-eslint/parser": "^4.9.0",
-        "eslint": "^7.14.0",
-        "eslint-config-prettier": "^6.15.0",
-        "eslint-plugin-import": "^2.22.0",
-        "eslint-plugin-prettier": "^3.2.0",
-        "eslint-plugin-react-hooks": "^4.0.8",
-        "prettier": "^2.2.1",
-        "typescript": "^4.1.2"
+        "@typescript-eslint/eslint-plugin": ">=4.9.0",
+        "@typescript-eslint/parser": ">=4.9.0",
+        "eslint": ">=7.14.0",
+        "eslint-config-prettier": ">=6.15.0",
+        "eslint-plugin-import": ">=2.22.0",
+        "eslint-plugin-prettier": ">=3.2.0",
+        "eslint-plugin-react-hooks": ">=4.0.8",
+        "prettier": ">=2.2.1",
+        "typescript": ">=3.8.3"
     },
     "engines": {
         "node": ">= 4"


### PR DESCRIPTION
## Description
Our Web.Project mono repo complains because we use higher versions
of some dependencies.

By using `>=` we're sure we can use a new major version of a dependency

## Checklist

- [ ] Test any new configuration on a repo using [`npm link`](https://docs.npmjs.com/cli/link)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-config-landr@0.6.1-canary.78.894e5f0.0
  # or 
  yarn add eslint-config-landr@0.6.1-canary.78.894e5f0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
