### PR TITLE
feat(lint): add pattern for typescript paths to eslint import order

### DIFF
--- a/packages/eslint-config-landr/index.js
+++ b/packages/eslint-config-landr/index.js
@@ -61,7 +61,19 @@ module.exports = {
                 enforceForRenamedProperties: false,
             },
         ],
-        'import/order': ['error', { 'newlines-between': 'never' }],
+        'import/order': [
+            'error',
+            {
+                'newlines-between': 'never',
+                pathGroups: [
+                    {
+                        pattern: '@/**',
+                        group: 'external',
+                        position: 'after',
+                    },
+                ],
+            },
+        ],
     },
     env: {
         browser: true,


### PR DESCRIPTION
## Description
When using typescript import paths, we need to keep the same order as without the paths.

Ex.

**Before**
```typescript
import external from '@external/plugin';
import { MyHook } from '../../../../hooks/myHook';
import { MyComponent } from './MyComponent';
```

**After**
```typescript
import external from '@external/plugin';
import { MyHook } from '@/hooks/myHook';
import { MyComponent } from './MyComponent';
```

Without changing the rule, the `@/` import was placed after the `./MyComponent`, which makes it a bit harder to read and find your sub components.

With the rule change, it keeps them in the same order.

## Checklist

- [x] Test any new configuration on a repo using [`npm link`](https://docs.npmjs.com/cli/link)
