### PR TITLE
fix(lingui): move lingui to dependecies

### DIFF
--- a/packages/eslint-config-landr/lingui.js
+++ b/packages/eslint-config-landr/lingui.js
@@ -2,18 +2,6 @@ module.exports = {
     extends: [],
     plugins: ['lingui'],
     rules: {
-        'no-restricted-imports': [
-            'error',
-            {
-                paths: [
-                    {
-                        name: '@lingui/react',
-                        importNames: ['Trans'],
-                        message: 'Please import Trans from @lingui/macro instead.',
-                    },
-                ],
-            },
-        ],
         'lingui/t-call-in-function': 'error',
         'lingui/no-expression-in-message': 'warn',
         'lingui/no-single-tag-to-translate': 'warn',

--- a/packages/eslint-config-landr/package.json
+++ b/packages/eslint-config-landr/package.json
@@ -28,7 +28,7 @@
         "eslint-plugin-lingui": "0.2.2",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.31.8",
-        "eslint-plugin-react-hooks": "4.6.0",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-testing-library": "^5.7.2"
     },
     "peerDependencies": {

--- a/packages/eslint-config-landr/package.json
+++ b/packages/eslint-config-landr/package.json
@@ -25,6 +25,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jest": "^26.1.1",
         "eslint-plugin-jsx-a11y": "6.6.1",
+        "eslint-plugin-lingui": "0.2.2",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.31.8",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -38,7 +39,6 @@
         "typescript": "^4.8.4"
     },
     "devDependencies": {
-        "eslint": "^8.10.0",
-        "eslint-plugin-lingui": "0.2.0"
+        "eslint": "^8.10.0"
     }
 }

--- a/packages/eslint-config-landr/package.json
+++ b/packages/eslint-config-landr/package.json
@@ -28,7 +28,7 @@
         "eslint-plugin-lingui": "0.2.2",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.31.8",
-        "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-react-hooks": "4.6.0",
         "eslint-plugin-testing-library": "^5.7.2"
     },
     "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2682,7 +2682,7 @@ eslint-plugin-prettier@^4.2.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react-hooks@^4.6.0:
+eslint-plugin-react-hooks@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2668,10 +2668,10 @@ eslint-plugin-jsx-a11y@6.6.1:
     minimatch "^3.1.2"
     semver "^6.3.0"
 
-eslint-plugin-lingui@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-lingui/-/eslint-plugin-lingui-0.2.0.tgz#4fd3355e964544f5d02fce0bea67187bf2f3ac3c"
-  integrity sha512-o63ySrDZlsujAaa3ybiFAjhkE1LHaKw5Z5GztiKHu1R+40tVOShy1XKvM+Q+vBykRXV9UrxE1oR79pUOSrsLVA==
+eslint-plugin-lingui@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lingui/-/eslint-plugin-lingui-0.2.2.tgz#22909b83da856832ec65b789f05b0455922c1a4e"
+  integrity sha512-orWu6o/IkCckLD0owLt+8fKy6SsIqIR9kz2L36KbCuAIfWg3dLRWC+XvuqQWEgJ4raRt+eoomTMunUJiBeogDQ==
   dependencies:
     "@typescript-eslint/utils" "^5.61.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2682,7 +2682,7 @@ eslint-plugin-prettier@^4.2.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react-hooks@4.6.0:
+eslint-plugin-react-hooks@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==


### PR DESCRIPTION
## Description
Move lingui to `dependecies`

## Checklist

- [ ] Test any new configuration on a repo using [`npm link`](https://docs.npmjs.com/cli/link)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-config-landr@1.3.1-canary.114.61031ac.0
  # or 
  yarn add eslint-config-landr@1.3.1-canary.114.61031ac.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
