### PR TITLE
feat: Add React Google Translate Plugin for ES Lint

### DIFF
--- a/packages/eslint-config-landr/package.json
+++ b/packages/eslint-config-landr/package.json
@@ -28,6 +28,7 @@
         "eslint-plugin-lingui": "~0.3.0",
         "eslint-plugin-prettier": "~5.2.1",
         "eslint-plugin-react": "~7.36.1",
+        "eslint-plugin-react-google-translate": "^0.0.114",
         "eslint-plugin-react-hooks": "~4.6.2",
         "eslint-plugin-testing-library": "~6.3.0"
     },

--- a/packages/eslint-config-landr/translate.js
+++ b/packages/eslint-config-landr/translate.js
@@ -1,0 +1,8 @@
+module.exports = {
+    extends: [],
+    plugins: ['react-google-translate'],
+    rules: {
+        'react-google-translate/no-conditional-text-nodes-with-siblings': 'warn',
+        'react-google-translate/no-return-text-nodes': 'warn',
+    },
+};

--- a/packages/eslint-config-landr/translate.js
+++ b/packages/eslint-config-landr/translate.js
@@ -2,7 +2,7 @@ module.exports = {
     extends: [],
     plugins: ['react-google-translate'],
     rules: {
-        'react-google-translate/no-conditional-text-nodes-with-siblings': 'warn',
-        'react-google-translate/no-return-text-nodes': 'warn',
+        'react-google-translate/no-conditional-text-nodes-with-siblings': 'error',
+        'react-google-translate/no-return-text-nodes': 'error',
     },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3017,6 +3017,13 @@ eslint-plugin-prettier@~5.2.1:
     prettier-linter-helpers "^1.0.0"
     synckit "^0.9.1"
 
+eslint-plugin-react-google-translate@^0.0.114:
+  version "0.0.114"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-google-translate/-/eslint-plugin-react-google-translate-0.0.114.tgz#4a4b6349b046e43e017c55c6a9ea8abbfca0a91c"
+  integrity sha512-ixV5l+ejPj3OdvlqSii4hnj42jAXy7EiMS65DvNQ40T5TkqD8RuSsYiIODTYDyoD3L3knLzF2LdTOQiqawMTGQ==
+  dependencies:
+    requireindex "^1.2.0"
+
 eslint-plugin-react-hooks@~4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
@@ -6136,6 +6143,11 @@ requireg@^0.2.2:
     nested-error-stacks "~2.0.1"
     rc "~1.2.7"
     resolve "~1.7.1"
+
+requireindex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Description

Adds an es lint plugin that helps identify cases where we are conditionally rendering text nodes next to other siblings. This is a known issue that can cause React to crash.

You can read more about the rules in the yarn package description

https://classic.yarnpkg.com/en/package/eslint-plugin-react-google-translate


Examples of code that will throw an error:
![CleanShot 2024-11-15 at 17 22 02@2x](https://github.com/user-attachments/assets/18196d19-df01-45d3-9a32-a3b32dab41b9)


## Checklist

- [ ] Test any new configuration on a repo using [`npm link`](https://docs.npmjs.com/cli/link)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-config-landr@1.5.0-canary.123.b43c1c5.0
  # or 
  yarn add eslint-config-landr@1.5.0-canary.123.b43c1c5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
