### PR TITLE
fix(prettier): support cjs and mts files

### DIFF
--- a/packages/prettier-config-landr/index.js
+++ b/packages/prettier-config-landr/index.js
@@ -17,7 +17,7 @@ module.exports = {
             },
         },
         {
-            files: '*.{js,ts,jsx,tsx,scss,json,html,mdx}',
+            files: '*.{js,ts,jsx,tsx,cjs,mjs,mts,scss,json,html,mdx}',
             options: {
                 tabWidth: 4,
             },


### PR DESCRIPTION
## Description
For modules files we could have `.cjs` and `.mjs` files to use a proper `module.exports` or `export default`

Update prettier config to support those files and
have the same indentation

## Checklist

- [x] Test any new configuration on a repo using [`npm link`](https://docs.npmjs.com/cli/link)
