### PR TITLE
fix(build): manually bump eslint-config-landr

### DIFF
--- a/packages/eslint-config-landr/package.json
+++ b/packages/eslint-config-landr/package.json
@@ -1,7 +1,7 @@
 {
     "name": "eslint-config-landr",
     "description": "LANDR's shareable ESLint config",
-    "version": "1.4.1",
+    "version": "1.5.0",
     "main": "index.js",
     "license": "MIT",
     "author": "LANDR <development@landr.com>",


### PR DESCRIPTION
## Description
Got an issue with master build that had wrong package.json version for eslint-config-landr

This aims to fix the build on master

## Checklist

- [ ] Test any new configuration on a repo using [`npm link`](https://docs.npmjs.com/cli/link)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-config-landr@1.5.1-canary.127.0fe2c54.0
  npm install prettier-config-landr@1.0.2-canary.127.0fe2c54.0
  # or 
  yarn add eslint-config-landr@1.5.1-canary.127.0fe2c54.0
  yarn add prettier-config-landr@1.0.2-canary.127.0fe2c54.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
